### PR TITLE
add an additional target to dockerfile for development

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/.devcontainer/compose.yaml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/.devcontainer/compose.yaml.tt
@@ -2,7 +2,8 @@ services:
   rails-app:
     build:
       context: ..
-      dockerfile: .devcontainer/Dockerfile
+      dockerfile: Dockerfile
+      target: devcontainer
 
     volumes:
     - ../..:/workspaces:cached

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -17,8 +17,8 @@ ENV RAILS_ENV="production" \
     BUNDLE_PATH="/usr/local/bundle" \
     BUNDLE_WITHOUT="development"
 
-# Throw-away build stage to reduce size of final image
-FROM base as build
+# Toolchain includes development/build dependencies
+FROM base as toolchain
 
 # Install packages needed to build gems<%= using_node? ? " and node modules" : "" %>
 RUN apt-get install --no-install-recommends -y <%= dockerfile_build_packages.join(" ") %>
@@ -41,6 +41,10 @@ ARG BUN_VERSION=<%= dockerfile_bun_version %>
 RUN curl -fsSL https://bun.sh/install | bash -s -- "bun-v${BUN_VERSION}"
 
 <% end -%>
+
+# Throw-away build stage to reduce size of final image
+FROM toolchain as build
+
 # Install application gems
 COPY Gemfile Gemfile.lock ./
 RUN bundle install && \
@@ -77,6 +81,10 @@ RUN bundle exec bootsnap precompile app/ lib/
 RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 
 <% end -%>
+
+FROM toolchain as devcontainer
+# Install packages needed for development here or add them via devconainer features if
+# you use devconainters in VSCode or other IDEs
 
 # Final stage for app image
 FROM base


### PR DESCRIPTION
### Motivation / Background
While development environments need tooling that you would not necessarily want in production it is beneficial to aim for parity where it makes sense. For this reason I think it would make sense to use the production dockerfile as a starting place.

This Pull Request has been created because to articulate how I envision that could work.

### Detail
Instead of using a separate Dockerfile for devcontainers, this PR adds some slight modifications to the production image to support using it in development. The changes include:
- Adds two new layers to the production dockerfile
  * Separate the installation of build tools from asset compilation into a new layer called toolchain
  * Add a new layer called devcontainer that is based from toolchain
- Point the compose to the main dockerfile and target the devcontainer layer.